### PR TITLE
Timing bug in "Tuples may be of mixed type"

### DIFF
--- a/src/test/scala/org/scalakoans/AboutTuples.scala
+++ b/src/test/scala/org/scalakoans/AboutTuples.scala
@@ -38,7 +38,7 @@ class AboutTuples extends KoanSuite {
     tuple5._1 should be ("a")
     tuple5._2 should __
     tuple5._3 should be (2.2)
-    tuple5._4.before(new Date()) should be (true)
+    tuple5._4.after(new Date()) should be (false)
     __ should be (BigDecimal(5))
   }
 


### PR DESCRIPTION
The test "Tuples may be of mixed type" in AboutTuples was failing sporadically for me. The problem seemed to be with the Date field: it created two Dates, and asserted that one of them was before the other, but if the test run quickly enough, they could be identical. So I changed it to assert that one of them wasn't after the other.
